### PR TITLE
Use source language when specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.1](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.1) - Source language bug fix - 2021-06
+
+- Use source language when specified instead of always auto-detecting due to being faster and possible detection mistakes
+
 ## [Version 1.0.0](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.0) - Initial release - 2021-04
 
 - ✨ Integration with the [Google Cloud Translation API - Basic edition](https://cloud.google.com/translate/docs/basic/translating-text)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.1) - Bugfix release - 2021-06
 
-- Use source language when specified instead of always auto-detecting due to being faster and possible detection mistakes
+- Fixed incorrectly ignored source language UI parameter (previously, it was always auto-detecting)
 
 ## [Version 1.0.0](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.0) - Initial release - 2021-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 1.0.1](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.1) - Source language bug fix - 2021-06
+## [Version 1.0.1](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.1) - Bugfix release - 2021-06
 
 - Use source language when specified instead of always auto-detecting due to being faster and possible detection mistakes
 

--- a/custom-recipes/nlp-google-cloud-translation-translate/recipe.py
+++ b/custom-recipes/nlp-google-cloud-translation-translate/recipe.py
@@ -73,6 +73,7 @@ df = api_parallelizer(
     error_handling=error_handling,
     text_column=text_column,
     target_language=target_language,
+    source_language=source_language
 )
 output_df = formatter.format_df(df)
 output_dataset.write_with_schema(output_df)

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "nlp-google-cloud-translation",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "meta": {
         "label": "Google Cloud Translation",
         "category": "Natural Language Processing",


### PR DESCRIPTION
See [ch65394](https://app.clubhouse.io/dataiku/story/65394/maintenance-use-source-languages-when-specified)