### PR TITLE
Fix formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Version 1.0.2](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.2) - Bugfix release - 2021-07
 
-- 🐛 Fixed formatting to default to Text and allow changing to HTML to avoid escaping of characters like '
+- 🐛 Fixed default input format to Text instead of HTML to avoid escaping special characters e.g., ' → &#39
 
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.1) - Bugfix release - 2021-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.0.2](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.2) - Bugfix release - 2021-07
+
+- 🐛 Fixed formatting to default to Text and allow changing to HTML to avoid escaping of characters like '
+
 ## [Version 1.0.1](https://github.com/dataiku/dss-plugin-nlp-google-cloud-translation/releases/tag/v1.0.1) - Bugfix release - 2021-06
 
 - 🐛 Fixed incorrectly ignored source language UI parameter (previously, it was always auto-detecting)

--- a/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
+++ b/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
@@ -941,7 +941,7 @@
     },
     {
       "name": "format",
-      "label": "Input Format",
+      "label": "Input format",
       "description": "Whether input format is plain text or html.",
       "type": "SELECT",
       "mandatory": false,

--- a/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
+++ b/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
@@ -952,7 +952,7 @@
         },
         {
           "value": "html",
-          "label": "html"
+          "label": "HTML"
         }
       ],
       "defaultValue": "text"

--- a/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
+++ b/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
@@ -948,7 +948,7 @@
       "selectChoices": [
         {
           "value": "text",
-          "label": "text"
+          "label": "Text"
         },
         {
           "value": "html",

--- a/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
+++ b/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
@@ -944,7 +944,7 @@
       "label": "Input format",
       "description": "Whether input format is plain text or html.",
       "type": "SELECT",
-      "mandatory": false,
+      "mandatory": true,
       "selectChoices": [
         {
           "value": "text",

--- a/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
+++ b/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
@@ -940,6 +940,24 @@
       "defaultValue": "en"
     },
     {
+      "name": "format",
+      "label": "Input Format",
+      "description": "Whether input format is plain text or html.",
+      "type": "SELECT",
+      "mandatory": false,
+      "selectChoices": [
+        {
+          "value": "text",
+          "label": "text"
+        },
+        {
+          "value": "html",
+          "label": "html"
+        }
+      ],
+      "defaultValue": "text"
+    },
+    {
       "name": "separator_configuration",
       "label": "Configuration",
       "type": "SEPARATOR"

--- a/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
+++ b/custom-recipes/nlp-google-cloud-translation-translate/recipe.json
@@ -941,8 +941,8 @@
     },
     {
       "name": "format",
-      "label": "Input format",
-      "description": "Whether input format is plain text or html.",
+      "label": "Format",
+      "description": "Whether input format is plain text or HTML",
       "type": "SELECT",
       "mandatory": true,
       "selectChoices": [


### PR DESCRIPTION
The GCloud translation API exposes a parameter for formatting, which by default is set to "html". This default assumes that the input text is HTML, which leads to the output being misformatted for special characters, such as in French:

`J'aime` becomes `J&#39;aime`

This PR sets the default to "text", as our users are more likely to have plain text rather than HTML data. The PR makes it configurable via the recipe.json.

References:
- https://googleapis.dev/python/translation/latest/_modules/google/cloud/translate_v2/client.html#Client.translate
- https://googleapis.dev/python/translation/latest/client.html



